### PR TITLE
(FIX) Fix WebVTT timestamps for the hour

### DIFF
--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -235,7 +235,7 @@ class WebVTTWriter(BaseWriter):
         hh, mm = divmod(mm, 60)
         s = "%02d:%02d.%03d" % (mm, ss, td.microseconds/1000)
         if hh:
-            s = "%d:%s" % (hh, s)
+            s = "%02d:%s" % (hh, s)
         return s
 
     def _tags_for_style(self, style):


### PR DESCRIPTION
Make sure the hour is double digit as per the spec.