### PR TITLE
Ignore unknown node types when laying out SCC lines

### DIFF
--- a/pycaption/scc/__init__.py
+++ b/pycaption/scc/__init__.py
@@ -570,6 +570,8 @@ class SCCWriter(BaseWriter):
                 return caption_node.content
             elif caption_node.type_ == CaptionNode.BREAK:
                 return '\n'
+            else:
+                return ''
         caption_text = ''.join(
             [caption_node_to_text(node) for node in caption.nodes])
         inner_lines = caption_text.split('\n')


### PR DESCRIPTION
Other node types don't contribute to the layout, so skip them with a zero-length string. Previously the inner function would return `None`, which can't be used.